### PR TITLE
Simulate location to run in simulator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 $:.unshift("/Library/RubyMotion/lib")
 require 'motion/project'
+require 'bubble-wrap'
 
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -23,6 +23,10 @@ class AppDelegate
       lm.startUpdatingLocation
       lm.delegate = self
     end
-    @location_manager.location.coordinate
+    if not Device.simulator?
+      @location_manager.location.coordinate
+    else 
+      SimulatePosition.new
+    end
   end
 end

--- a/app/simulate_position.rb
+++ b/app/simulate_position.rb
@@ -1,0 +1,9 @@
+class SimulatePosition
+  def latitude
+    37.780026
+  end
+
+  def longitude
+    -122.391289
+  end
+end


### PR DESCRIPTION
This change detects if the app is being run in the iPhone Simulator and, if it is, provides a simulated position to prevent the crash described in Issue #1. It's not particularly clever or robust, though---just enough to get it running immediately in the Simulator.